### PR TITLE
New json schema ids

### DIFF
--- a/json-schema/datablock/asset_list_query.json
+++ b/json-schema/datablock/asset_list_query.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Asset List Query Datablock",
-	"$id": "/datablock/asset_list_query.json",
-	"$comment": "This datablock is just a variable query with no other fields.",
+	"$id": "af.datablock.asset_list_query",
+	"description": "Datablock containing the variable query for listing assets.",
 	"$ref":"../template/variable_query.json"
 }

--- a/json-schema/datablock/authors.json
+++ b/json-schema/datablock/authors.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Authors Datablock",
-	"$id": "/datablock/authors.json",
-	"$comment": "This datablock contains information about the authors of a provider or an individual asset.",
+	"$id": "af.datablock.authors",
+	"description": "This datablock contains information about the authors of a provider or an individual asset.",
 	"type":"array",
 	"items": {
 		"type":"object",

--- a/json-schema/datablock/branding.json
+++ b/json-schema/datablock/branding.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Branding Datablock",
-	"$id": "/datablock/branding.json",
-	"$comment": "This datablock contains branding information about a provider.",
+	"$id": "af.datablock.branding",
+	"description": "This datablock contains branding information about a provider.",
 	"type": "object",
 	"properties": {
 		"color_accent": {

--- a/json-schema/datablock/dimensions.2d.json
+++ b/json-schema/datablock/dimensions.2d.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Dimensions (2D) Datablock",
-	"$id": "/datablock/dimensions.2d.json",
-	"$comment": "This datablock describes physical dimensions for 2D assets.",
+	"$id": "af.datablock.dimensions.2d",
+	"description": "This datablock describes physical dimensions for 2D assets.",
 	"type": "object",
 	"properties": {
 		"width_m": {

--- a/json-schema/datablock/dimensions.3d.json
+++ b/json-schema/datablock/dimensions.3d.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Dimensions (3D) Datablock",
-	"$id": "/datablock/dimensions.3d.json",
-	"$comment": "This datablock describes physical dimensions for 3D assets.",
+	"$id": "af.datablock.dimensions.3d",
+	"description": "This datablock describes physical dimensions for 3D assets.",
 	"type": "object",
 	"properties": {
 		"width_m": {

--- a/json-schema/datablock/file_fetch.download.json
+++ b/json-schema/datablock/file_fetch.download.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "File Fetch Datablock",
-	"$id": "/datablock/file_fetch.download.json",
+	"$id": "af.datablock.file_fetch.download",
+	"description": "This datablock contains the fixed query for downloading a component file as part of an asset implementation.",
     "$ref":"../template/fixed_query.json"
 }

--- a/json-schema/datablock/file_fetch.from_archive.json
+++ b/json-schema/datablock/file_fetch.from_archive.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "File Fetch Datablock",
-	"$id": "/datablock/file_fetch.from_archive.json",
+	"$id": "af.datablock.file_fetch.from_archive",
+	"description": "This datablock contains information about how to load a component file from an archive (represented as another component).",
 	"type":"object",
 	"properties": {
 		"archive_component_name":{

--- a/json-schema/datablock/file_info.json
+++ b/json-schema/datablock/file_info.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "File Info Datablock",
-	"$id": "/datablock/file_into.json",
+	"$id": "af.datablock.file_info",
+	"description": "Datablock for general information about a component file.",
 	"type":"object",
     "properties": {
         "local_path":{

--- a/json-schema/datablock/format.blend.json
+++ b/json-schema/datablock/format.blend.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": ".blend File Datablock",
-	"$id": "/datablock/format.blend.json",
-	"$comment": "This datablock describes details about a .blend file for Blender.",
+	"$id": "af.datablock.format.blend",
+	"description": "This datablock describes details about a .blend file for Blender.",
 	"type": "object",
 	"properties": {
 		"version": {

--- a/json-schema/datablock/format.obj.json
+++ b/json-schema/datablock/format.obj.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": ".obj File Datablock",
-	"$id": "/datablock/format.obj.json",
+	"$id": "af.datablock.format.obj",
 	"type": "object",
 	"properties": {
 		"up_axis": {

--- a/json-schema/datablock/format.usd.json
+++ b/json-schema/datablock/format.usd.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": ".usd File Datablock",
-	"$id": "/datablock/format.usd.json",
+	"$id": "af.datablock.format.usd",
+	"description": "This datablock contains information about a file in the openUSD format.",
 	"type": "object",
 	"properties": {
 		"is_crate":{

--- a/json-schema/datablock/implementation_list_query.json
+++ b/json-schema/datablock/implementation_list_query.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Implementation List Query Datablock",
-	"$id": "/datablock/implementation_list_query.json",
-	"$comment": "This datablock is just a variable query with no other fields.",
+	"$id": "af.datablock.implementation_list_query.json",
+	"description": "This datablock is contains the query to list the implementations for an asset.",
 	"$ref":"../template/variable_query.json"
 }

--- a/json-schema/datablock/license.json
+++ b/json-schema/datablock/license.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "License Datablock",
-	"$id": "/datablock/license.json",
+	"$id": "af.datablock.license",
+	"description": "This datablock contains licensing information for an asset or an entire provider",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/loose_environment.json
+++ b/json-schema/datablock/loose_environment.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Loose Environment Datablock",
-	"$id": "/datablock/loose_environment.json",
+	"$id": "af.datablock.loose_environment",
+	"description": "This datablock describes a loose environment.",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/loose_material_apply.json
+++ b/json-schema/datablock/loose_material_apply.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Loose Material Application Datablock",
-	"$id": "/datablock/loose_material_apply.json",
+	"$id": "af.datablock.loose_material_apply",
+	"description": "This datablock describes how to apply a loose material to the current component.",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/loose_material_define.json
+++ b/json-schema/datablock/loose_material_define.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Loose Material Definition Datablock",
-	"$id": "/datablock/loose_material_apply.json",
+	"$id": "af.datablock.loose_material_apply",
+	"description": "This datablock indicates that this component is part of a loose material (usually this means that the datablock is a PBR map).",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/mtlx_apply.json
+++ b/json-schema/datablock/mtlx_apply.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "MTLX Apply Material Datablock",
-	"$id": "/datablock/mtlx_apply_material.json",
+	"$id": "af.datablock.mtlx_apply_material",
+	"description": "This datablock contains information about how to apply a referenced mtlx material from another component to the current component.",
 	"type": "object",
 	"properties": {
 		"mtlx_component": {

--- a/json-schema/datablock/next_query.json
+++ b/json-schema/datablock/next_query.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Next Query Datablock",
-	"$id": "/datablock/next_query.json",
-	"$comment": "This datablock is just a variable query with no other fields.",
+	"$id": "af.datablock.next_query",
+	"description": "This datablock describes how to fetch more results for the current query.",
 	"$ref":"../template/variable_query.json"
 }

--- a/json-schema/datablock/preview_image_supplemental.json
+++ b/json-schema/datablock/preview_image_supplemental.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Preview Image (Supplemental) Datablock",
-	"$id": "/datablock/preview_image_supplemental.json",
+	"$id": "af.datablock.preview_image_supplemental",
+	"description": "This datablock describes supplemental preview images for an asset.",
 	"type": "array",
 	"items": {
 		"type": "object",

--- a/json-schema/datablock/preview_image_thumbnail.json
+++ b/json-schema/datablock/preview_image_thumbnail.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Preview Image (Thumbnail) Datablock",
-	"$id": "/datablock/preview_image_thumbnail.json",
+	"$id": "af.datablock.preview_image_thumbnail",
+	"description": "This datablock describes the main thumbnail image (and its possible resolutions).",
 	"type": "object",
 	"properties": {
 		"alt":{

--- a/json-schema/datablock/provider_configuration.json
+++ b/json-schema/datablock/provider_configuration.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Provider Configuration Datablock",
-	"$id": "/datablock/provider_configuration.json",
+	"$id": "af.datablock.provider_configuration",
+	"description": "This datablock contains provider configuration data, like which headers the provider expects to receive from the client.",
 	"type": "object",
 	"properties": {
 		"acquisition_uri": {

--- a/json-schema/datablock/provider_reconfiguration.json
+++ b/json-schema/datablock/provider_reconfiguration.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Provider Configuration Datablock",
-	"$id": "/datablock/provider_configuration.json",
+	"$id": "af.datablock.provider_reconfiguration",
+	"description": "This datablock can be sent by the provider to reconfigure which headers the client should send to the provider.",
 	"type": "object",
 	"properties": {
 		"headers": {

--- a/json-schema/datablock/response_statistics.json
+++ b/json-schema/datablock/response_statistics.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Next Query Datablock",
-	"$id": "/datablock/next_query.json",
-	"$comment": "This datablock is just a variable query with no other fields.",
+	"$id": "af.datablock.response_statistics",
+	"description": "This datablock can be used by the provider to indicate the total number of results in a query.",
 	"type":"object",
     "properties": {
         "result_count_total":{

--- a/json-schema/datablock/text.json
+++ b/json-schema/datablock/text.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Text Datablock",
-	"$id": "/datablock/text.json",
+	"$id": "af.datablock.text",
+	"description": "This datablock contains basic text information.",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/unlock_balance.json
+++ b/json-schema/datablock/unlock_balance.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Unlocking Balance Datablock",
-	"$id": "/datablock/unlock_balance.json",
+	"$id": "af.datablock.unlock_balance",
+	"description": "This datablock contains information about the user's account balance.",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/unlock_link.json
+++ b/json-schema/datablock/unlock_link.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Unlock Link Datablock",
-	"$id": "/datablock/unlock_link.json",
+	"$id": "af.datablock.unlock_link",
+	"description": "This datablock describes which unlocking query must be triggered for this component to become accessible and how to then get the proper download link for a component.",
 	"type":"object",
 	"properties": {
 		"unlock_query_id":{

--- a/json-schema/datablock/unlock_queries.json
+++ b/json-schema/datablock/unlock_queries.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Unlock Queries Datablock",
-	"$id": "/datablock/unlock_queries.json",
+	"$id": "af.datablock.unlock_queries",
+	"description": "This datablock describes the unlocking queries a specific asset.",
 	"type": "array",
 	"items": {
 		"$comment": "",

--- a/json-schema/datablock/user.json
+++ b/json-schema/datablock/user.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "User Datablock",
-	"$id": "/datablock/user.json",
+	"$id": "af.datablock.user",
+	"description": "This datablock describes the current user.",
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {

--- a/json-schema/datablock/web_references.json
+++ b/json-schema/datablock/web_references.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Web References Datablock",
-	"$id": "/datablock/web_references.json",
+	"$id": "af.datablock.web_references",
+	"description": "This datablock describes web references that can be attached to other resources.",
 	"type": "array",
 	"additionalItems": false,
 	"items": {

--- a/json-schema/endpoint/asset_list.json
+++ b/json-schema/endpoint/asset_list.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Asset List Endpoint",
-	"$id": "/endpoint/asset_list.json",
+	"$id": "af.endpoint.asset_list",
+	"description": "This endpoint can be used to query assets.",
 	"type": "object",
 	"properties": {
 		"meta": {

--- a/json-schema/endpoint/connection_status.json
+++ b/json-schema/endpoint/connection_status.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Connection Status Endpoint",
-	"$id": "/endpoint/asset_list.json",
+	"$id": "af.endpoint.connection_status",
+	"description": "This endpoint can be used to gather data about the current connection status.",
 	"type": "object",
 	"properties": {
 		"meta": {
@@ -11,8 +12,8 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
-				"unlock_status": {
-					"$ref":"../datablock/unlock_status.json"
+				"unlock_balance": {
+					"$ref":"../datablock/unlock_balance.json"
 				},
 				"user": {
 					"$ref":"../datablock/user.json"

--- a/json-schema/endpoint/generic.json
+++ b/json-schema/endpoint/generic.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id":"generic.json",
+	"$id":"af.endpoint.generic",
 	"type": "object",
 	"properties": {
 		"meta": {

--- a/json-schema/endpoint/implementation_list.json
+++ b/json-schema/endpoint/implementation_list.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Implementation List Endpoint",
-	"$id": "/endpoint/implementation_list.json",
+	"$id": "af.endpoint.implementation_list",
+	"description": "This endpoint gets the list of possible implementations for a specific asset.",
 	"type": "object",
 	"properties": {
 		"meta": {

--- a/json-schema/endpoint/initialization.json
+++ b/json-schema/endpoint/initialization.json
@@ -1,5 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "af.endpoint.initialization",
+	"description": "This is the initialization endpoint which the client first connects with.",
 	"type": "object",
 	"properties": {
 		"meta": {

--- a/json-schema/endpoint/unlock.json
+++ b/json-schema/endpoint/unlock.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Unlocking Endpoint",
-	"$id": "/endpoint/unlock.json",
+	"$id": "af.endpoint.unlock",
+	"description": "This is an endpoint for unlocking resources.",
 	"type": "object",
 	"properties": {
 		"meta": {

--- a/json-schema/endpoint/unlocked_datablocks.json
+++ b/json-schema/endpoint/unlocked_datablocks.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Unlocked Datablocks Endpoint",
-	"$id": "/endpoint/unlocked_datablocks.json",
+	"$id": "af.endpoint.unlocked_datablocks",
+	"description": "This endpoint returns the previously withheld file_fetch.download datablock for a component.",
 	"type": "object",
 	"properties": {
 		"meta": {

--- a/json-schema/template/fixed_query.json
+++ b/json-schema/template/fixed_query.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Fixed Query Template",
-	"$id":"/template/fixed_query.json",
+	"$id":"af.template.fixed_query",
+	"description": "This template represents a fixed query.",
 	"type": "object",
 	"properties": {
 		"uri": {

--- a/json-schema/template/meta.json
+++ b/json-schema/template/meta.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id":"/template/meta.json",
+	"$id":"af.template.meta",
+	"description": "This template contains metadata for every endpoint.",
 	"type": "object",
 	"properties": {
 		"response_id": {

--- a/json-schema/template/variable_query.json
+++ b/json-schema/template/variable_query.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Variable Query Template",
-	"$id": "/template/variable_query.json",
+	"$id": "af.template.variable_query",
+	"description": "This template describes a variable query that is configurable by the user.",
 	"type": "object",
 	"properties": {
 		"uri": {


### PR DESCRIPTION
This PR reworks the `$id` field in the JSON schema. The old system used slashes which messed with the implementation in the default jsonschema python library. The new schema uses the format `af.<type>.<name>` which prevents these IDs from being interpreted as absolute file paths.