### PR TITLE
Allow named HDRI environments

### DIFF
--- a/json-schema/datablock/loose_environment.json
+++ b/json-schema/datablock/loose_environment.json
@@ -9,9 +9,13 @@
 		"projection":{
 			"type":"string",
 			"enum": ["equirectangular","mirror_ball"]
+		},
+		"environment_name":{
+			"type":"string"
 		}
 	},
 	"required": [
-		"projection"
+		"projection",
+		"environment_name"
 	]
 }

--- a/spec.md
+++ b/spec.md
@@ -1031,9 +1031,10 @@ The presence of this datablock on a component indicates that it is an environmen
 This datablock only needs to be applied if the component is a "bare file", like (HDR or EXR), not if the environment is already wrapped in another format with native support.
 An object that MUST conform to this format:
 
-| Field        | Format | Required | Description                             |
-| ------------ | ------ | -------- | --------------------------------------- |
-| `projection` | string | yes      | One of `equirectangular`, `mirror_ball` |
+| Field              | Format | Required | Description                             |
+| ------------------ | ------ | -------- | --------------------------------------- |
+| `projection`       | string | yes      | One of `equirectangular`, `mirror_ball` |
+| `environment_name` | string | yes      |                                         |
 
 ### 8.5.2. `loose_material.define`
 


### PR DESCRIPTION
This PR introduces a new `environment_name` field for the `loose_environment` datablock.